### PR TITLE
Move to CDDO GitHub org

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -30,8 +30,8 @@ allprojects {
 
 sonarqube {
   properties {
-    property "sonar.projectKey", "alphagov_federated-api-model_examples-java"
-    property "sonar.organization", "alphagov"
+    property "sonar.projectKey", "co-cddo_federated-api-model_examples-java"
+    property "sonar.organization", "co-cddo"
     property "sonar.host.url", "https://sonarcloud.io"
   }
 }


### PR DESCRIPTION
As we now can do, we should move over, which requires tweaking our
SonarQube configuration to point to the new `projectKey` and org.
