### PR TITLE
Add an `api-version` field for `BulkMetadataResponse`

### DIFF
--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
@@ -28,13 +28,13 @@ class BulkMetadataResponseTest {
 
     @Test
     void apisIsSerializedWhenPresent() throws IOException {
-      BulkMetadataResponse BulkMetadataResponse = new BulkMetadataResponse();
+      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
       List<ApiMetadata> apiMetadata = new ArrayList<>();
       ApiMetadata apiMetadataObject = new ApiMetadata();
       apiMetadata.add(apiMetadataObject);
-      BulkMetadataResponse.setApis(apiMetadata);
+      bulkMetadataResponse.setApis(apiMetadata);
 
-      jsonContent = jacksonTester.write(BulkMetadataResponse);
+      jsonContent = jacksonTester.write(bulkMetadataResponse);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").hasSize(1);
     }
@@ -62,9 +62,9 @@ class BulkMetadataResponseTest {
 
     @Test
     void apisIsSerializedAsAnEmptyArrayWhenNotInitialised() throws IOException {
-      BulkMetadataResponse BulkMetadataResponse = new BulkMetadataResponse();
+      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
 
-      jsonContent = jacksonTester.write(BulkMetadataResponse);
+      jsonContent = jacksonTester.write(bulkMetadataResponse);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").isEmpty();
     }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
@@ -68,6 +68,18 @@ class BulkMetadataResponseTest {
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").isEmpty();
     }
+
+    @Test
+    void apiVersionIsSerialized() throws IOException {
+      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
+      bulkMetadataResponse.setApiVersion(BulkMetadataResponse.ApiVersion.API_GOV_UK_V_1_ALPHA);
+
+      jsonContent = jacksonTester.write(bulkMetadataResponse);
+
+      assertThat(jsonContent)
+          .extractingJsonPathStringValue("api-version")
+          .isEqualTo("api.gov.uk/v1alpha");
+    }
   }
 
   @Nested

--- a/schemas/v1alpha/bulk-metadata-response.json
+++ b/schemas/v1alpha/bulk-metadata-response.json
@@ -5,9 +5,17 @@
   "description": "A JSON Schema to manage the format of API response objects",
   "type": "object",
   "required": [
+    "api-version",
     "apis"
   ],
   "properties": {
+    "api-version": {
+      "$comment": "The version of this bulk metadata response object",
+      "type": "string",
+      "enum": [
+        "api.gov.uk/v1alpha"
+      ]
+    },
     "apis": {
       "type": "array",
       "items": {


### PR DESCRIPTION
We want versioning for the response object as well as the API metadata,
so that we can manage changes to it.