### PR TITLE
Make all Gradle builds reproducible

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -26,6 +26,11 @@ allprojects {
       endWithNewline()
     }
   }
+
+  tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+  }
 }
 
 sonarqube {


### PR DESCRIPTION
Reproducible builds is one of the things for the highest level of [Supply-chain
Levels for Software Artifacts
(SLSA)](https://slsa.dev/requirements#reproducible).

One of the main advantages of this is security - because the output is always the same if
the source code doesn't change, you know that nothing has been modified to
inject vulnerabilities. This feature is easy to add in Gradle so worth doing.

I tested it's working by doing a `./gradlew clean build` in the `spring-boot` project multiple times and checking that the checksum of the jar file didn't change.