### PR TITLE
Add link to the Project board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Federated API Discovery Model
 
 Repository containing all work related to the [Data Standards Authority's](https://alphagov.github.io/data-standards-authority/) work towards producing a federated API discovery model for UK Government.
+
+## Project Backlog
+
+As well as GitHub issues on the repository, we also have a [Project](https://github.com/orgs/co-cddo/projects/1) set up for this repository.


### PR DESCRIPTION
As it's not discoverable as a new Beta Project, which is currently
configured at the org- not project-level.
