### PR TITLE
Add initial Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/examples/java"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/schemas"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
To make sure we're keeping on top of our dependency updates, we should
enable Dependabot.

As we're using a Monorepo with different `package-ecosystem`s, we need
to make sure we add them each, with the paths and ecosystem.
