### PR TITLE
Add buildSrc to Dependabot configuration 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "gradle"
+    directory: "/examples/java/buildSrc"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "npm"
     directory: "/schemas"
     schedule:


### PR DESCRIPTION
- Add initial Dependabot configuration
- Add `buildSrc` to Dependabot configuration
