### PR TITLE
Automagically label PRs with the repos they affect

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+'🔧 GitHub Configuration':
+  - '.github/**/*'
+'📁 Repo: examples/java':
+  - 'examples/java/**/*'
+'📁 Repo: schemas':
+  - 'schemas/**/*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
To improve visibility of what repos are changing in PRs, we can
utilise the `labeler` Action to auto-label PRs with what's affected.

We also want to enable `sync-labels` to make sure that changes to files
once the PR is raised to make sure that the labels stay updated.
