### PR TITLE
Bump com.diffplug.spotless from 6.0.0 to 6.0.4 in /examples/java

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.diffplug.spotless' version '6.0.0'
+  id 'com.diffplug.spotless' version '6.0.4'
   id "org.sonarqube" version "3.3"
   id 'uk.gov.api.common-conventions'
 }


### PR DESCRIPTION
Bumps com.diffplug.spotless from 6.0.0 to 6.0.4.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
