### PR TITLE
Use `var` for some variables

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
@@ -21,8 +21,8 @@ public class MetadataController {
   @GetMapping(produces = "application/vnd.uk.gov.api.v1alpha+json")
   public BulkMetadataResponse retrieveAll() {
     List<ApiMetadata> apiMetadata = service.retrieveAll();
-    BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
-    bulkMetadataResponse.setApis(apiMetadata);
-    return bulkMetadataResponse;
+    var response = new BulkMetadataResponse();
+    response.setApis(apiMetadata);
+    return response;
   }
 }

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/services/MetadataService.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/services/MetadataService.java
@@ -24,9 +24,9 @@ public class MetadataService {
 
   private static Function<MetadataDao, ApiMetadata> convertToApiMetadata() {
     return dao -> {
-      ApiMetadata apiMetadata = new ApiMetadata();
+      var apiMetadata = new ApiMetadata();
       apiMetadata.setApiVersion(ApiMetadata.ApiVersion.fromValue(dao.getApiVersion()));
-      Data data = new Data();
+      var data = new Data();
       data.setName(dao.getName());
       data.setDescription(dao.getDescription());
       data.setUrl(URI.create(dao.getUrl()));

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerIntegrationTest.java
@@ -41,12 +41,12 @@ class MetadataControllerIntegrationTest {
 
     @Test
     void mockDataIsReturned() throws Exception {
-      ApiMetadata apiMetadata1 = new ApiMetadata();
-      Data data1 = new Data();
+      var apiMetadata1 = new ApiMetadata();
+      var data1 = new Data();
       data1.setName("API 1");
       apiMetadata1.setData(data1);
-      ApiMetadata apiMetadata2 = new ApiMetadata();
-      Data data2 = new Data();
+      var apiMetadata2 = new ApiMetadata();
+      var data2 = new Data();
       data2.setName("API 2");
       apiMetadata2.setData(data2);
 

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/ApiMetadataTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/ApiMetadataTest.java
@@ -26,7 +26,7 @@ public class ApiMetadataTest {
 
     @Test
     void apiVersionIsSerialized() throws IOException {
-      ApiMetadata apiMetadata = new ApiMetadata();
+      var apiMetadata = new ApiMetadata();
       apiMetadata.setApiVersion(ApiMetadata.ApiVersion.API_GOV_UK_V_1_ALPHA);
 
       jsonContent = jacksonTester.write(apiMetadata);
@@ -38,8 +38,8 @@ public class ApiMetadataTest {
 
     @Test
     void dataIsSerialized() throws IOException {
-      Data data = new Data();
-      ApiMetadata apiMetadata = new ApiMetadata();
+      var data = new Data();
+      var apiMetadata = new ApiMetadata();
       apiMetadata.setData(data);
 
       jsonContent = jacksonTester.write(apiMetadata);

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 import models.metadata.ApiMetadata;
 import models.metadata.BulkMetadataResponse;
 import org.junit.jupiter.api.Disabled;
@@ -28,53 +27,53 @@ class BulkMetadataResponseTest {
 
     @Test
     void apisIsSerializedWhenPresent() throws IOException {
-      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
-      List<ApiMetadata> apiMetadata = new ArrayList<>();
-      ApiMetadata apiMetadataObject = new ApiMetadata();
+      var response = new BulkMetadataResponse();
+      var apiMetadata = new ArrayList<ApiMetadata>();
+      var apiMetadataObject = new ApiMetadata();
       apiMetadata.add(apiMetadataObject);
-      bulkMetadataResponse.setApis(apiMetadata);
+      response.setApis(apiMetadata);
 
-      jsonContent = jacksonTester.write(bulkMetadataResponse);
+      jsonContent = jacksonTester.write(response);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").hasSize(1);
     }
 
     @Test
     void apisIsSerializedAsAnEmptyArrayWhenEmpty() throws IOException {
-      List<ApiMetadata> apiMetadata = new ArrayList<>();
-      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
-      bulkMetadataResponse.setApis(apiMetadata);
+      var apiMetadata = new ArrayList<ApiMetadata>();
+      var response = new BulkMetadataResponse();
+      response.setApis(apiMetadata);
 
-      jsonContent = jacksonTester.write(bulkMetadataResponse);
+      jsonContent = jacksonTester.write(response);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").isEmpty();
     }
 
     @Test
     void apisIsNullWhenResponseIsNull() throws IOException {
-      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
-      bulkMetadataResponse.setApis(null);
+      var response = new BulkMetadataResponse();
+      response.setApis(null);
 
-      jsonContent = jacksonTester.write(bulkMetadataResponse);
+      jsonContent = jacksonTester.write(response);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").isNull();
     }
 
     @Test
     void apisIsSerializedAsAnEmptyArrayWhenNotInitialised() throws IOException {
-      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
+      var response = new BulkMetadataResponse();
 
-      jsonContent = jacksonTester.write(bulkMetadataResponse);
+      jsonContent = jacksonTester.write(response);
 
       assertThat(jsonContent).extractingJsonPathArrayValue("apis").isEmpty();
     }
 
     @Test
     void apiVersionIsSerialized() throws IOException {
-      BulkMetadataResponse bulkMetadataResponse = new BulkMetadataResponse();
-      bulkMetadataResponse.setApiVersion(BulkMetadataResponse.ApiVersion.API_GOV_UK_V_1_ALPHA);
+      var response = new BulkMetadataResponse();
+      response.setApiVersion(BulkMetadataResponse.ApiVersion.API_GOV_UK_V_1_ALPHA);
 
-      jsonContent = jacksonTester.write(bulkMetadataResponse);
+      jsonContent = jacksonTester.write(response);
 
       assertThat(jsonContent)
           .extractingJsonPathStringValue("api-version")

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/DataTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/DataTest.java
@@ -26,7 +26,7 @@ class DataTest {
   class Serialization {
     @BeforeEach
     void setup() throws IOException {
-      Data data = new Data();
+      var data = new Data();
       data.setName("some name");
       data.setDescription("some description");
       data.setUrl(URI.create("https://www.example.foo"));

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/repositories/EmptyMetadataRepositoryTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/repositories/EmptyMetadataRepositoryTest.java
@@ -9,14 +9,14 @@ class EmptyMetadataRepositoryTest {
 
   @Test
   void findAllReturnsEmptyList() {
-    EmptyMetadataRepository repository = new EmptyMetadataRepository();
+    var repository = new EmptyMetadataRepository();
 
     assertThat(repository.findAll()).isEmpty();
   }
 
   @Test
   void findAllReturnsUnmodifiableList() {
-    EmptyMetadataRepository repository = new EmptyMetadataRepository();
+    var repository = new EmptyMetadataRepository();
 
     var actual = repository.findAll();
 

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/services/MetadataServiceTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/services/MetadataServiceTest.java
@@ -36,7 +36,7 @@ class MetadataServiceTest {
 
     @Test
     void mapsApiVersion() {
-      MetadataDao dao = getMetadataDao();
+      var dao = getMetadataDao();
       when(repository.findAll()).thenReturn(List.of(dao));
 
       List<ApiMetadata> actual = service.retrieveAll();
@@ -47,11 +47,11 @@ class MetadataServiceTest {
 
     @Test
     void mapsName() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setName("name 1");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setName("name 2");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setName("name 3");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
 
@@ -65,11 +65,11 @@ class MetadataServiceTest {
 
     @Test
     void mapsDescription() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setDescription("description 1");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setDescription("description 2");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setDescription("description 3");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
 
@@ -83,12 +83,12 @@ class MetadataServiceTest {
 
     @Test
     void mapsUrl() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setUrl("https://www.example.foo");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setUrl("https://www.example.bar");
       dao2.setApiVersion("api.gov.uk/v1alpha");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setUrl("https://www.example.baz");
       dao3.setApiVersion("api.gov.uk/v1alpha");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
@@ -103,11 +103,11 @@ class MetadataServiceTest {
 
     @Test
     void mapsContact() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setContact("contact 1");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setContact("contact 2");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setContact("contact 3");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
 
@@ -121,11 +121,11 @@ class MetadataServiceTest {
 
     @Test
     void mapsOrganisation() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setOrganisation("org 1");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setOrganisation("org 2");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setOrganisation("org 3");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
 
@@ -139,11 +139,11 @@ class MetadataServiceTest {
 
     @Test
     void mapsDocumentationUrl() {
-      MetadataDao dao1 = getMetadataDao();
+      var dao1 = getMetadataDao();
       dao1.setDocumentationUrl("https://www.exampledocs.foo");
-      MetadataDao dao2 = getMetadataDao();
+      var dao2 = getMetadataDao();
       dao2.setDocumentationUrl("https://www.exampledocs.bar");
-      MetadataDao dao3 = getMetadataDao();
+      var dao3 = getMetadataDao();
       dao3.setDocumentationUrl("https://www.exampledocs.baz");
       when(repository.findAll()).thenReturn(List.of(dao1, dao2, dao3));
 
@@ -156,7 +156,7 @@ class MetadataServiceTest {
     }
 
     private MetadataDao getMetadataDao() {
-      MetadataDao dao = new MetadataDao();
+      var dao = new MetadataDao();
       dao.setApiVersion("api.gov.uk/v1alpha");
       dao.setUrl("https://foo.bar");
       dao.setDocumentationUrl("https://foo.baz");


### PR DESCRIPTION
When it's easy to infer the type from the context, using `var` can make code
more readable.