### PR TITLE
Update Log4J to 2.17.0

### DIFF
--- a/examples/java/buildSrc/src/main/groovy/uk.gov.api.spring-boot-conventions.gradle
+++ b/examples/java/buildSrc/src/main/groovy/uk.gov.api.spring-boot-conventions.gradle
@@ -10,4 +10,4 @@ configurations {
   testRuntimeOnly.exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 }
 
-ext['log4j2.version'] = '2.16.0'
+ext['log4j2.version'] = '2.17.0'


### PR DESCRIPTION
As this version is now available, we should use it, as it remediates a
CVE.
