### PR TITLE
Ensure `api-version` is included in the response

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
@@ -23,6 +23,7 @@ public class MetadataController {
     List<ApiMetadata> apiMetadata = service.retrieveAll();
     var response = new BulkMetadataResponse();
     response.setApis(apiMetadata);
+    response.setApiVersion(BulkMetadataResponse.ApiVersion.API_GOV_UK_V_1_ALPHA);
     return response;
   }
 }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerTest.java
@@ -31,6 +31,8 @@ class MetadataControllerTest {
       BulkMetadataResponse actual = controller.retrieveAll();
 
       assertThat(actual.getApis()).isEqualTo(apiMetadata);
+      assertThat(actual.getApiVersion())
+          .isEqualTo(BulkMetadataResponse.ApiVersion.API_GOV_UK_V_1_ALPHA);
     }
   }
 }


### PR DESCRIPTION
The API version wasn't being shown as we were never setting it anywhere, so
make sure we explicitly set it and add an assertion to the controller test to
verify this.

Closes #31.