### PR TITLE
Validate that /apis matches JSON schema

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -15,7 +15,15 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-log4j2'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
+  testImplementation 'io.rest-assured:json-schema-validator:4.4.0'
 }
+
+task copySchemas(type: Copy) {
+  from '../../../schemas/v1alpha'
+  include '*.json'
+  into file("${project.buildDir}/resources/test/schemas/v1alpha")
+}
+processTestResources.finalizedBy copySchemas
 
 jsonSchema2Pojo {
   source = files(fileTree(dir: '../../../schemas/v1alpha', include: ['*.json']))


### PR DESCRIPTION
As noted in 469762e8a2af3a8c0b96e993df2c874bdc252570, we found a case
where our API's response didn't actually match the JSON Schema that we
said it was, as we didn't have quite enough validation available.

To avoid hitting common issues in the future, we can ensure that we
validate that the response from the API validates against the schema.

This requires we:

- make the schemas available for the tests' runtime classpath, by
  copying them into the build directory's test resources directory
- utilise Rest Assured's JSON Schema Validator, as it has a handy
  Hamcrest matcher that we can use together with Spring's
  `content().string()` method
- set up the test with correctly formed `ApiMetadata` objects
