### PR TITLE
Add code-ql analysis

### DIFF
--- a/.github/workflows/examples-java-codeql-analysis.yml
+++ b/.github/workflows/examples-java-codeql-analysis.yml
@@ -1,0 +1,40 @@
+name: "CodeQL Analysis"
+
+on:
+  push: {}
+  pull_request:
+    paths:
+      - "examples/java/**"
+      - ".github/workflows/examples-java-codeql-analysis.yml"
+  schedule:
+    - cron: '36 12 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/java
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: 'java'
+
+    - name: Build project
+      run: ./gradlew clean build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This keeps the default of scanning code when someone pushes a change or a pull request is created, to prevent us from introducing new vulnerabilities. It also runs once a week on Sunday so that we know about new vulnerabilities even if we aren't actively maintaining the repository.