### PR TITLE
Rename the package containing models

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -28,5 +28,5 @@ processTestResources.finalizedBy copySchemas
 jsonSchema2Pojo {
   source = files(fileTree(dir: '../../../schemas/v1alpha', include: ['*.json']))
   targetDirectory = file("${project.buildDir}/generated-sources/js2p")
-  targetPackage = "models.metadata"
+  targetPackage = "uk.gov.api.models.metadata"
 }

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/controllers/MetadataController.java
@@ -1,11 +1,11 @@
 package uk.gov.api.springboot.controllers;
 
 import java.util.List;
-import models.metadata.ApiMetadata;
-import models.metadata.BulkMetadataResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.BulkMetadataResponse;
 import uk.gov.api.springboot.services.MetadataService;
 
 @RestController

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/services/MetadataService.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/services/MetadataService.java
@@ -3,9 +3,9 @@ package uk.gov.api.springboot.services;
 import java.net.URI;
 import java.util.List;
 import java.util.function.Function;
-import models.metadata.ApiMetadata;
-import models.metadata.Data;
 import org.springframework.stereotype.Service;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.Data;
 import uk.gov.api.springboot.daos.MetadataDao;
 import uk.gov.api.springboot.repositories.MetadataRepository;
 

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerIntegrationTest.java
@@ -7,8 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.restassured.module.jsv.JsonSchemaValidator;
 import java.net.URI;
 import java.util.List;
-import models.metadata.ApiMetadata;
-import models.metadata.Data;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +20,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.Data;
 import uk.gov.api.springboot.services.MetadataService;
 
 @AutoConfigureMockMvc

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/controllers/MetadataControllerTest.java
@@ -4,14 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import models.metadata.ApiMetadata;
-import models.metadata.BulkMetadataResponse;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.BulkMetadataResponse;
 import uk.gov.api.springboot.services.MetadataService;
 
 @ExtendWith(MockitoExtension.class)

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/ApiMetadataTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/ApiMetadataTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
-import models.metadata.ApiMetadata;
-import models.metadata.Data;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.json.JsonContent;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.Data;
 
 @JsonTest
 public class ApiMetadataTest {

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/BulkMetadataResponseTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import models.metadata.ApiMetadata;
-import models.metadata.BulkMetadataResponse;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.json.JsonContent;
+import uk.gov.api.models.metadata.ApiMetadata;
+import uk.gov.api.models.metadata.BulkMetadataResponse;
 
 @JsonTest
 class BulkMetadataResponseTest {

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/DataTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/models/metadata/DataTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URI;
-import models.metadata.Data;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -14,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.boot.test.json.JsonContent;
+import uk.gov.api.models.metadata.Data;
 
 @JsonTest
 class DataTest {

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/services/MetadataServiceTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/services/MetadataServiceTest.java
@@ -5,13 +5,13 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.List;
-import models.metadata.ApiMetadata;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.api.models.metadata.ApiMetadata;
 import uk.gov.api.springboot.daos.MetadataDao;
 import uk.gov.api.springboot.repositories.MetadataRepository;
 


### PR DESCRIPTION
Use the standard Java convention of naming packages after the organisation that
created them.  We haven't included springboot in the name as these classes
aren't owned by that module.

Closes #32