### PR TITLE
Deploy the spring boot app to PaaS

### DIFF
--- a/.github/workflows/examples-java-push.yml
+++ b/.github/workflows/examples-java-push.yml
@@ -55,3 +55,30 @@ jobs:
           name: examples-java-reports
           path: '**/build/reports/*'
           retention-days: 5
+      - name: Upload spring-boot manifest
+        uses: actions/upload-artifact@v2
+        with:
+          name: spring-boot-manifest
+          path: 'examples/java/spring-boot/manifest.yml'
+          retention-days: 5
+  deploy:
+    environment: sandbox
+    runs-on: ubuntu-18.04
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: examples-java-libs
+      - uses: actions/download-artifact@v2
+        with:
+          name: spring-boot-manifest
+      - name: Deploy to PaaS
+        uses: citizen-of-planet-earth/cf-cli-action@v2
+        with:
+          cf_api: https://api.london.cloud.service.gov.uk
+          cf_username: ${{ secrets.CF_USER }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: cabinet-office-cddo-dsa-apis
+          cf_space: sandbox
+          command: push -f manifest.yml -p examples/java/spring-boot/build/libs/federated-api-model.jar

--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -30,3 +30,7 @@ jsonSchema2Pojo {
   targetDirectory = file("${project.buildDir}/generated-sources/js2p")
   targetPackage = "uk.gov.api.models.metadata"
 }
+
+bootJar {
+  archiveName = 'federated-api-model.jar'
+}

--- a/examples/java/spring-boot/manifest.yml
+++ b/examples/java/spring-boot/manifest.yml
@@ -1,0 +1,7 @@
+---
+applications:
+  - name: federated-api-model-spring-boot-sandbox
+    buildpacks:
+      - https://github.com/cloudfoundry/java-buildpack.git#v4.47
+    env:
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+ } }'


### PR DESCRIPTION
We've renamed the jar file we're building so that we can explicitly use the name for the `cf push` command without having to worry about updating the version.

We're not checking out the repo in the deploy job because we only need the jar file and the manifest file to push to PaaS, which we can reuse from the test job.