### PR TITLE
Add actuator dependency to the spring boot app

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-layout-template-json'
   implementation 'org.springframework.boot:spring-boot-starter-log4j2'
   implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.rest-assured:json-schema-validator:4.4.0'
 }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/HealthCheckIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/HealthCheckIntegrationTest.java
@@ -1,0 +1,22 @@
+package uk.gov.api.springboot;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthCheckIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void returns200() throws Exception {
+    mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
This is mainly so that we can use the `actuator/health` endpoint, but we might
also want to use it for things like audit logging.

#52 depends on this being merged first