### PR TITLE
Run healthcheck on the spring boot app in PaaS

### DIFF
--- a/examples/java/spring-boot/manifest.yml
+++ b/examples/java/spring-boot/manifest.yml
@@ -5,3 +5,5 @@ applications:
       - https://github.com/cloudfoundry/java-buildpack.git#v4.47
     env:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+ } }'
+    health-check-type: http
+    health-check-http-endpoint: '/actuator/health'


### PR DESCRIPTION
This should be merged after #51, otherwise the deployment will fail because it won't find the healthcheck url.

Adding the healthcheck to the manifest file means that when the app is deployed
to PaaS, Cloud Foundry will run a healthcheck every 2 seconds until it's
healthy, and after that every 30 seconds. If it becomes unhealthy it will stop
and delete the app instance and try to create a new one:
https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#understand-healthchecks