### PR TITLE
Fix typo in `additionalProperties` in schemas

### DIFF
--- a/schemas/v1alpha/api-metadata.json
+++ b/schemas/v1alpha/api-metadata.json
@@ -63,5 +63,5 @@
       }
     }
   },
-  "additionalproperties": true
+  "additionalProperties": true
 }

--- a/schemas/v1alpha/bulk-metadata-response.json
+++ b/schemas/v1alpha/bulk-metadata-response.json
@@ -23,5 +23,5 @@
       }
     }
   },
-  "additionalproperties": true
+  "additionalProperties": true
 }


### PR DESCRIPTION
Changing this to camelCase so that it's clearly set.

Closes #55 