### PR TITLE
Add initial ArchUnit rules

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -15,6 +15,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-log4j2'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  testImplementation 'com.tngtech.archunit:archunit:0.22.0'
+  testImplementation 'com.tngtech.archunit:archunit-junit5:0.22.0'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.rest-assured:json-schema-validator:4.5.0'
 }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchUnitTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchUnitTest.java
@@ -1,0 +1,36 @@
+package uk.gov.api.springboot.architecture;
+
+import static com.tngtech.archunit.base.DescribedPredicate.describe;
+import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
+import org.junit.jupiter.api.Nested;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@AnalyzeClasses(packages = "uk.gov.api.springboot")
+class ArchUnitTest {
+  @ArchTest
+  @SuppressWarnings("unused")
+  ArchRule requireFinalFields =
+      classesThatAreNotTests().and().haveNameNotMatching(".*Dao").should().haveOnlyFinalFields();
+
+  @ArchTest
+  @SuppressWarnings("unused")
+  ArchRule requireNoAutowiredFieldInjection =
+      classesThatAreNotTests()
+          .and()
+          .containAnyFieldsThat(
+              describe(
+                  "are Autowired by Spring",
+                  f -> f.tryGetAnnotationOfType(Autowired.class).isPresent()))
+          .should()
+          .containNumberOfElements(equalTo(0));
+
+  private GivenClassesConjunction classesThatAreNotTests() {
+    return classes().that().haveNameNotMatching(".*Test").and().areNotAnnotatedWith(Nested.class);
+  }
+}


### PR DESCRIPTION

Arch Unit can help us codify our technical architecture, and we can
start with adding two rules:

- ensuring that we use `final` fields for immutable classes where
  possible
- ensure we don't use field injection with Spring, because it's not
  recommended by a lot of people - including me

This allows us to shift from requiring overhead in code review, to
enforcing it automagically.

