### PR TITLE
Be more restrictive of Actions' token permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: "Pull Request Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-scorecards-analysis.yml
+++ b/.github/workflows/main-scorecards-analysis.yml
@@ -6,7 +6,8 @@ on:
   push:
     branches: [ main ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/openapi-docs-pr.yml
+++ b/.github/workflows/openapi-docs-pr.yml
@@ -6,6 +6,10 @@ on:
       - '.github/workflows/openapi-docs-pr.yml'
       - 'schemas/.spectral.yml'
       - "schemas/*/openapi.yml"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Run Spectral

--- a/.github/workflows/openapi-docs-push.yml
+++ b/.github/workflows/openapi-docs-push.yml
@@ -6,6 +6,10 @@ on:
       - '.github/workflows/openapi-docs-push.yml'
       - 'schemas/.spectral.yml'
       - "schemas/*/openapi.yml"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Run Spectral


### PR DESCRIPTION
Ahead of restricting default access to `read` across the organisation,
we should make sure that we can reduce the permissions required for our
Actions accordingly, including downgrading `read-all` to
`contents:read`.