### PR TITLE
Migrate ArchUnit rules to method-based rules

### DIFF
--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchUnitTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchUnitTest.java
@@ -4,9 +4,9 @@ import static com.tngtech.archunit.base.DescribedPredicate.describe;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
 import org.junit.jupiter.api.Nested;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,25 +14,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 @AnalyzeClasses(packages = "uk.gov.api.springboot")
 class ArchUnitTest {
   @ArchTest
-  @SuppressWarnings("unused")
-  ArchRule requireFinalFields =
-      classesThatAreNotTests()
-          .and()
-          .resideOutsideOfPackage("uk.gov.api.springboot.infrastructure.models.metadata..")
-          .should()
-          .haveOnlyFinalFields();
+  void requireFinalFields(JavaClasses classes) {
+    classesThatAreNotTests()
+        .and()
+        .resideOutsideOfPackage("uk.gov.api.springboot.infrastructure.models.metadata..")
+        .should()
+        .haveOnlyFinalFields()
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  ArchRule requireNoAutowiredFieldInjection =
-      classesThatAreNotTests()
-          .and()
-          .containAnyFieldsThat(
-              describe(
-                  "are Autowired by Spring",
-                  f -> f.tryGetAnnotationOfType(Autowired.class).isPresent()))
-          .should()
-          .containNumberOfElements(equalTo(0));
+  void requireNoAutowiredFieldInjection(JavaClasses classes) {
+    classesThatAreNotTests()
+        .and()
+        .containAnyFieldsThat(
+            describe(
+                "are Autowired by Spring",
+                f -> f.tryGetAnnotationOfType(Autowired.class).isPresent()))
+        .should()
+        .containNumberOfElements(equalTo(0))
+        .check(classes);
+  }
 
   private GivenClassesConjunction classesThatAreNotTests() {
     return classes().that().haveNameNotMatching(".*Test").and().areNotAnnotatedWith(Nested.class);

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchitectureLayeringTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/architecture/ArchitectureLayeringTest.java
@@ -3,9 +3,9 @@ package uk.gov.api.springboot.architecture;
 import static com.tngtech.archunit.base.DescribedPredicate.describe;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
 import org.jmolecules.architecture.onion.classical.ApplicationServiceRing;
 import org.jmolecules.archunit.JMoleculesArchitectureRules;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,65 +21,73 @@ class ArchitectureLayeringTest {
   private static final String DOMAIN_RING = "..domain..";
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule onionArchitecture = JMoleculesArchitectureRules.ensureOnionClassical();
+  void onionArchitecture(JavaClasses classes) {
+    JMoleculesArchitectureRules.ensureOnionClassical().check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule mockMvcAnnotationShouldOnlyBeUsedInInfrastructureRing =
-      classes()
-          .that()
-          .areAnnotatedWith(AutoConfigureMockMvc.class)
-          .should()
-          .resideInAPackage(INFRASTRUCTURE_RING);
+  void mockMvcAnnotationShouldOnlyBeUsedInInfrastructureRing(JavaClasses classes) {
+    classes()
+        .that()
+        .areAnnotatedWith(AutoConfigureMockMvc.class)
+        .should()
+        .resideInAPackage(INFRASTRUCTURE_RING)
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule webMvcTestAnnotationShouldOnlyBeUsedInInfrastructureRing =
-      classes()
-          .that()
-          .areAnnotatedWith(WebMvcTest.class)
-          .should()
-          .resideInAPackage(INFRASTRUCTURE_RING);
+  void webMvcTestAnnotationShouldOnlyBeUsedInInfrastructureRing(JavaClasses classes) {
+    classes()
+        .that()
+        .areAnnotatedWith(WebMvcTest.class)
+        .should()
+        .resideInAPackage(INFRASTRUCTURE_RING)
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule springBootTestAnnotationShouldOnlyBeUsedInApplicationOrInfrastructureRing =
-      classes()
-          .that()
-          .areAnnotatedWith(SpringBootTest.class)
-          .should()
-          .resideInAnyPackage(APPLICATION_RING, INFRASTRUCTURE_RING);
+  void springBootTestAnnotationShouldOnlyBeUsedInApplicationOrInfrastructureRing(
+      JavaClasses classes) {
+    classes()
+        .that()
+        .areAnnotatedWith(SpringBootTest.class)
+        .should()
+        .resideInAnyPackage(APPLICATION_RING, INFRASTRUCTURE_RING)
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule springBootApplicationAnnotationShouldOnlyBeUsedInApplicationRing =
-      classes()
-          .that()
-          .areAnnotatedWith(SpringBootApplication.class)
-          .should()
-          .resideInAPackage(APPLICATION_RING)
-          .orShould()
-          .beAnnotatedWith(ApplicationServiceRing.class);
+  void springBootApplicationAnnotationShouldOnlyBeUsedInApplicationRing(JavaClasses classes) {
+    classes()
+        .that()
+        .areAnnotatedWith(SpringBootApplication.class)
+        .should()
+        .resideInAPackage(APPLICATION_RING)
+        .orShould()
+        .beAnnotatedWith(ApplicationServiceRing.class)
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule mockMvcShouldOnlyBeUsedInInfrastructureRing =
-      classes()
-          .that()
-          .containAnyFieldsThat(
-              describe(
-                  "are instances of `MockMvc`", f -> f.getRawType().isEquivalentTo(MockMvc.class)))
-          .should()
-          .resideInAPackage(INFRASTRUCTURE_RING);
+  void mockMvcShouldOnlyBeUsedInInfrastructureRing(JavaClasses classes) {
+    classes()
+        .that()
+        .containAnyFieldsThat(
+            describe(
+                "are instances of `MockMvc`", f -> f.getRawType().isEquivalentTo(MockMvc.class)))
+        .should()
+        .resideInAPackage(INFRASTRUCTURE_RING)
+        .check(classes);
+  }
 
   @ArchTest
-  @SuppressWarnings("unused")
-  private final ArchRule domainRingIsSelfSufficient =
-      classes()
-          .that()
-          .resideInAPackage(DOMAIN_RING)
-          .should()
-          .onlyAccessClassesThat()
-          .resideInAnyPackage(DOMAIN_RING, "java..");
+  void domainRingIsSelfSufficient(JavaClasses classes) {
+    classes()
+        .that()
+        .resideInAPackage(DOMAIN_RING)
+        .should()
+        .onlyAccessClassesThat()
+        .resideInAnyPackage(DOMAIN_RING, "java..")
+        .check(classes);
+  }
 }


### PR DESCRIPTION

As IntelliJ's not (yet) got support for the field-based rules being
tests themselves, we have a not great developer experience, resulting in
us needing to run the whole test class, rather than re-run a single
rule.

We can amend this by replacing it with a method-based rule setup, which
requires we add the `.check()` call on an injected `JavaClasses` object.

Closes #76.

