### PR TITLE
Specify path to jar file for deployment

### DIFF
--- a/.github/workflows/examples-java-push.yml
+++ b/.github/workflows/examples-java-push.yml
@@ -92,5 +92,5 @@ jobs:
           cf target -o "${CF_ORG}" -s "${CF_SPACE}"
       - name: Deploy to PaaS
         run: |
-          cf push -f manifest.yml --strategy rolling
+          cf push -f manifest.yml -p examples/java/spring-boot/build/libs/federated-api-model.jar --strategy rolling
           cf logout


### PR DESCRIPTION
Because we have a monorepo structure we need to specify the path to where the
jar file is built, as cloudfoundry won't find it otherwise.