### PR TITLE
Move plugin declarations to `buildSrc`

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'com.diffplug.spotless' version '6.2.2'
-  id "org.sonarqube" version "3.3"
+  id 'com.diffplug.spotless'
+  id "org.sonarqube"
   id 'uk.gov.api.common-conventions'
 }
 

--- a/examples/java/buildSrc/build.gradle
+++ b/examples/java/buildSrc/build.gradle
@@ -25,5 +25,7 @@ ext {
 }
 
 dependencies {
+  implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.2.2'
+  implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
   implementation "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 }


### PR DESCRIPTION
We're seeing that Dependabot is bumping the version of Spotless in two
separate PRs - one for `buildSrc` and one for the main project.

This is a bit awkward, and can be hopefully minimised by putting the
plugins into `buildSrc`'s `implementation` classpath.

This then means that versions of plugins can be controlled in a single
place.

---

To be merged before #91 and #92.