### PR TITLE
Bump com.diffplug.spotless in /examples/java/buildSrc

### DIFF
--- a/examples/java/buildSrc/build.gradle
+++ b/examples/java/buildSrc/build.gradle
@@ -25,7 +25,7 @@ ext {
 }
 
 dependencies {
-  implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.2.2'
+  implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
   implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
   implementation "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 }


### PR DESCRIPTION
Bumps com.diffplug.spotless from 6.2.2 to 6.3.0.

---
updated-dependencies:
- dependency-name: com.diffplug.spotless
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>