### PR TITLE
chore/archunit

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -19,7 +19,6 @@ dependencies {
   implementation 'me.jvt.spring:spring-content-negotiator:0.1.0'
   implementation 'me.jvt.uuid:uuid-core:0.8.1'
   testImplementation 'com.github.valfirst:slf4j-test:2.5.0'
-  testImplementation 'com.tngtech.archunit:archunit:0.22.0'
   testImplementation 'com.tngtech.archunit:archunit-junit5:0.22.0'
   testImplementation 'org.jmolecules.integrations:jmolecules-archunit:0.8.0'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
- Execute Spectral when Spectral configuration changes
- Execute workflows when CI configuration has changed
- Only trigger CodeQL in subrepo
- Deploy the spring boot app to PaaS
- Add actuator dependency to the spring boot app
- Run healthcheck on the spring boot app in PaaS
- Bump com.diffplug.spotless in /examples/java/buildSrc
- Fix typo in `additionalProperties` in schemas
- Move models to `v1alpha` package
- Ensure we use JDK17 for CodeQL
- Migrate to `temurin` JDK
- Bump spring-boot-gradle-plugin in /examples/java/buildSrc
- Create Scorecards workflow
- Bump json-schema-validator from 4.4.0 to 4.5.0 in /examples/java
- Add initial ArchUnit rules
- Don't return HTTP objects from Service layer
- Bump ossf/scorecard-action from 1.0.1 to 1.0.2
- Remove pinning comments
- Add a README for the spring-boot project
- Use a relative link for OpenAPI JSON Schema include
- Migrate to NPM task for Spectral linting
- Use `spectral-ruleset-govuk-public` for API linting
- Remove duplicate dependency definition
- Bump @stoplight/spectral-cli from 6.1.1 to 6.2.0 in /schemas
- Bump ossf/scorecard-action from 1.0.2 to 1.0.3
- Bump com.diffplug.spotless in /examples/java/buildSrc
- Be more restrictive of Actions' token permissions
- Add an ADR for using correlation IDs
- Add a correlation id to our contract
- Add error handling for the correlation-id filter
- Add the correlation-id to the MDC
- Bump uuid-core from 0.8.0 to 0.8.1 in /examples/java
- Bump @stoplight/spectral-cli from 6.2.0 to 6.2.1 in /schemas
- Bump slf4j-test from 2.4.1 to 2.5.0 in /examples/java
- Bump com.diffplug.spotless in /examples/java/buildSrc
- Bump com.diffplug.spotless from 6.1.0 to 6.2.2 in /examples/java
- Don't return DAO objects from `MetadataRepository`
- Replace `Metadata` references with `Api`
- Move `v1alpha` controllers to their own package
- Migrate to Onion Architecture
- Remove unnecessary `ExtendWith`
- Require Domain ring is only POJOs
- Add documentation for the onion architecture approach
- Migrate ArchUnit rules to method-based rules
- Add a CODEOWNERS file
- Remove use of 3rd party action for deploying to PaaS
- Add rolling deployments for pushing to PaaS
- Pin external worklows to specific versions
- Set top level permissions for CodeQL analysis workflow
- Update username variable for deployment
- Specify path to jar file for deployment
- Bump json-schema-validator from 4.5.0 to 4.5.1 in /examples/java
- Bump github/codeql-action from 1 to 1.0.32
- Bump github/codeql-action from 1.0.32 to 1.1.0
- Bump vm2 from 3.9.5 to 3.9.7 in /schemas
- Move plugin declarations to `buildSrc`
- Use a wildcard static import for slf4j-test
- Bump com.diffplug.spotless in /examples/java/buildSrc
- Bump com.diffplug.spotless in /examples/java/buildSrc
- Bump ossf/scorecard-action from 1.0.3 to 1.0.4
- Bump github/codeql-action from 1.1.0 to 1.1.2
- Remove explicit core Archunit version
