### PR TITLE
Add a scheduled method

### DIFF
--- a/examples/java/spring-boot/build.gradle
+++ b/examples/java/spring-boot/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation 'me.jvt.uuid:uuid-core:0.8.1'
   testImplementation 'com.github.valfirst:slf4j-test:2.5.0'
   testImplementation 'com.tngtech.archunit:archunit-junit5:0.23.1'
+  testImplementation 'org.awaitility:awaitility:4.1.1'
   testImplementation 'org.jmolecules.integrations:jmolecules-archunit:0.8.0'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'io.rest-assured:json-schema-validator:4.5.1'

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/application/NoopRegistry.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/application/NoopRegistry.java
@@ -1,0 +1,14 @@
+package uk.gov.api.springboot.application;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import uk.gov.api.springboot.domain.model.Registry;
+
+@Component
+public class NoopRegistry implements Registry {
+  @Override
+  public List<Entry> retrieveAll() {
+    return Collections.emptyList();
+  }
+}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/application/services/NoopFetcherService.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/application/services/NoopFetcherService.java
@@ -1,0 +1,17 @@
+package uk.gov.api.springboot.application.services;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import uk.gov.api.springboot.domain.model.Api;
+import uk.gov.api.springboot.domain.model.Registry;
+import uk.gov.api.springboot.domain.services.FetcherService;
+
+@Component
+public class NoopFetcherService implements FetcherService {
+
+  @Override
+  public List<Api> fetch(Registry.Entry entry) {
+    return Collections.emptyList();
+  }
+}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/Registry.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/Registry.java
@@ -1,0 +1,14 @@
+package uk.gov.api.springboot.domain.model;
+
+import java.util.List;
+
+/**
+ * Interface representing a registry, which returns a list of entries representing external services
+ * to parse.
+ */
+public interface Registry {
+
+  List<Entry> retrieveAll();
+
+  record Entry(String id, String baseUrl) {}
+}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/repositories/ApiStorage.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/repositories/ApiStorage.java
@@ -5,5 +5,7 @@ import uk.gov.api.springboot.domain.model.Api;
 
 public interface ApiStorage {
 
+  void save(Api api);
+
   List<Api> findAll();
 }

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/services/FetcherService.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/services/FetcherService.java
@@ -1,0 +1,11 @@
+package uk.gov.api.springboot.domain.services;
+
+import java.util.List;
+import uk.gov.api.springboot.domain.model.Api;
+import uk.gov.api.springboot.domain.model.Registry;
+
+/** Interface representing a fetcher service, which fetches lists of APIs from external services. */
+public interface FetcherService {
+
+  List<Api> fetch(Registry.Entry entry);
+}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/ScheduleHandler.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/ScheduleHandler.java
@@ -1,0 +1,19 @@
+package uk.gov.api.springboot.infrastructure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScheduleHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScheduleHandler.class);
+
+  @Scheduled(fixedRateString = "${apis-fetch-rate.in.milliseconds}")
+  public void fetchAndSaveApis() {
+    LOGGER.info("Fetching and saving APIS");
+
+    LOGGER.info("Finished fetching and saving APIs");
+  }
+}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/ScheduleHandler.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/ScheduleHandler.java
@@ -4,15 +4,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.gov.api.springboot.domain.model.Registry;
+import uk.gov.api.springboot.domain.model.repositories.ApiStorage;
+import uk.gov.api.springboot.domain.services.FetcherService;
 
 @Component
 public class ScheduleHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScheduleHandler.class);
+  private final FetcherService fetcherService;
+  private final Registry registry;
+  private final ApiStorage storage;
+
+  public ScheduleHandler(FetcherService fetcherService, Registry registry, ApiStorage storage) {
+    this.fetcherService = fetcherService;
+    this.registry = registry;
+    this.storage = storage;
+  }
 
   @Scheduled(fixedRateString = "${apis-fetch-rate.in.milliseconds}")
   public void fetchAndSaveApis() {
     LOGGER.info("Fetching and saving APIS");
+
+    // Save each list of APIs individually rather than flattening the list, so we don't have to wait
+    // for all lists to be fetched before we start saving.
+    registry.retrieveAll().forEach(entry -> fetcherService.fetch(entry).forEach(storage::save));
 
     LOGGER.info("Finished fetching and saving APIs");
   }

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/ScheduleConfiguration.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/ScheduleConfiguration.java
@@ -1,0 +1,8 @@
+package uk.gov.api.springboot.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfiguration {}

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/repositories/EmptyApiStorage.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/repositories/EmptyApiStorage.java
@@ -10,6 +10,12 @@ import uk.gov.api.springboot.domain.model.repositories.ApiStorage;
 public class EmptyApiStorage implements ApiStorage {
 
   @Override
+  public void save(Api api) {
+    // We'll implement this in a separate step, by just storing a list in memory to begin
+    // with.
+  }
+
+  @Override
   public List<Api> findAll() {
     return Collections.emptyList();
   }

--- a/examples/java/spring-boot/src/main/resources/application.properties
+++ b/examples/java/spring-boot/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+apis-fetch-rate.in.milliseconds = 3600000

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/application/NoopRegistryTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/application/NoopRegistryTest.java
@@ -1,0 +1,23 @@
+package uk.gov.api.springboot.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class NoopRegistryTest {
+
+  private final NoopRegistry registry = new NoopRegistry();
+
+  @Test
+  void findAllReturnsEmptyList() {
+    assertThat(registry.retrieveAll()).isEmpty();
+  }
+
+  @Test
+  void findAllReturnsUnmodifiableList() {
+    var actual = registry.retrieveAll();
+
+    assertThatThrownBy(() -> actual.add(null)).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/application/services/NoopFetcherServiceTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/application/services/NoopFetcherServiceTest.java
@@ -1,0 +1,26 @@
+package uk.gov.api.springboot.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.api.springboot.domain.model.Registry;
+
+class NoopFetcherServiceTest {
+
+  private final NoopFetcherService fetcherService = new NoopFetcherService();
+
+  @Test
+  void fetchReturnsAnEmptyList() {
+    assertThat(fetcherService.fetch(null)).isEmpty();
+  }
+
+  @Test
+  void fetchReturnsUnmodifiableList() {
+    var registryEntry = new Registry.Entry("123", "www.example.com");
+
+    var actual = fetcherService.fetch(registryEntry);
+
+    assertThatThrownBy(() -> actual.add(null)).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
@@ -1,0 +1,40 @@
+package uk.gov.api.springboot.infrastructure;
+
+import static com.github.valfirst.slf4jtest.Assertions.*;
+
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ScheduleHandlerTest {
+
+  private final ScheduleHandler handler = new ScheduleHandler();
+
+  @Nested
+  class Log {
+
+    private final TestLogger logger = TestLoggerFactory.getTestLogger(ScheduleHandler.class);
+
+    @AfterEach
+    void tearDown() {
+      logger.clear();
+    }
+
+    @Test
+    void messageIsLoggedWhenScheduledTaskIsStarted() {
+      handler.fetchAndSaveApis();
+
+      assertThat(logger).hasLogged(LoggingEvent.info("Fetching and saving APIS"));
+    }
+
+    @Test
+    void messageIsLoggedWhenScheduledTaskIsFinished() {
+      handler.fetchAndSaveApis();
+
+      assertThat(logger).hasLogged(LoggingEvent.info("Finished fetching and saving APIs"));
+    }
+  }
+}

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
@@ -1,17 +1,33 @@
 package uk.gov.api.springboot.infrastructure;
 
 import static com.github.valfirst.slf4jtest.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.github.valfirst.slf4jtest.LoggingEvent;
 import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.api.springboot.domain.model.Api;
+import uk.gov.api.springboot.domain.model.Registry;
+import uk.gov.api.springboot.domain.model.repositories.ApiStorage;
+import uk.gov.api.springboot.domain.services.FetcherService;
 
+@ExtendWith(MockitoExtension.class)
 class ScheduleHandlerTest {
 
-  private final ScheduleHandler handler = new ScheduleHandler();
+  @Mock private Registry registry;
+  @Mock private ApiStorage storage;
+  @Mock private FetcherService fetcherService;
+  @InjectMocks private ScheduleHandler handler;
 
   @Nested
   class Log {
@@ -36,5 +52,27 @@ class ScheduleHandlerTest {
 
       assertThat(logger).hasLogged(LoggingEvent.info("Finished fetching and saving APIs"));
     }
+  }
+
+  @Test
+  void registryEntriesArePassedToFetcher() {
+    var entry = new Registry.Entry("123", "https://api-endpoint.example");
+    when(registry.retrieveAll()).thenReturn(List.of(entry));
+
+    handler.fetchAndSaveApis();
+
+    verify(fetcherService).fetch(entry);
+  }
+
+  @Test
+  void apisAreSavedToStorage() {
+    var entry = new Registry.Entry("123", "https://api-endpoint.example-one");
+    when(registry.retrieveAll()).thenReturn(List.of(entry));
+    Api api = new Api("v1", null, null, null, null, null, null);
+    when(fetcherService.fetch(any())).thenReturn(List.of(api));
+
+    handler.fetchAndSaveApis();
+
+    verify(storage).save(api);
   }
 }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduledHandlerIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduledHandlerIntegrationTest.java
@@ -1,0 +1,23 @@
+package uk.gov.api.springboot.infrastructure;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import org.awaitility.Durations;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest(properties = "apis-fetch-rate.in.milliseconds = 500")
+class ScheduledHandlerIntegrationTest {
+
+  @SpyBean private ScheduleHandler handler;
+
+  @Test
+  void testFetchAndSaveApisCalledOnSchedule() {
+    await()
+        .atMost(Durations.ONE_SECOND)
+        .untilAsserted(() -> verify(handler, atLeast(1)).fetchAndSaveApis());
+  }
+}

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CorrelationIdFilterTest {
 
+  private static final String EXAMPLE_VALID_CORRELATION_ID = "93094CAB-21D7-43EC-97E9-566573544781";
   @Mock private HttpServletRequest request;
   @Mock private HttpServletResponse response;
   @Mock private FilterChain filterChain;
@@ -108,32 +109,30 @@ class CorrelationIdFilterTest {
       @Test
       void correlationIdIsAddedToMdcBeforeFilterChainContinues()
           throws ServletException, IOException {
-        String correlationId = "93094CAB-21D7-43EC-97E9-566573544781";
-        when(request.getHeader("correlation-id")).thenReturn(correlationId);
+        when(request.getHeader("correlation-id")).thenReturn(EXAMPLE_VALID_CORRELATION_ID);
 
         filter.doFilterInternal(request, response, filterChain);
 
         InOrder inOrder = inOrder(mdcFacade, filterChain);
-        inOrder.verify(mdcFacade).put("correlation-id", correlationId);
+        inOrder.verify(mdcFacade).put("correlation-id", EXAMPLE_VALID_CORRELATION_ID);
         inOrder.verify(filterChain).doFilter(request, response);
       }
 
       @Test
       void thatARequestWasSent() throws ServletException, IOException {
-        String correlationId = "93094CAB-21D7-43EC-97E9-566573544781";
-        when(request.getHeader("correlation-id")).thenReturn(correlationId);
+        when(request.getHeader("correlation-id")).thenReturn(EXAMPLE_VALID_CORRELATION_ID);
 
         filter.doFilterInternal(request, response, filterChain);
 
         assertThat(logger)
             .hasLogged(
-                LoggingEvent.info("A request was sent with correlation-id {}", correlationId));
+                LoggingEvent.info(
+                    "A request was sent with correlation-id {}", EXAMPLE_VALID_CORRELATION_ID));
       }
 
       @Test
       void messageIsLoggedBeforeFilterChainContinues() throws ServletException, IOException {
-        String correlationId = "93094CAB-21D7-43EC-97E9-566573544781";
-        when(request.getHeader("correlation-id")).thenReturn(correlationId);
+        when(request.getHeader("correlation-id")).thenReturn(EXAMPLE_VALID_CORRELATION_ID);
         doThrow(new IOException()).when(filterChain).doFilter(any(), any());
 
         assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
@@ -141,7 +140,8 @@ class CorrelationIdFilterTest {
 
         assertThat(logger)
             .hasLogged(
-                LoggingEvent.info("A request was sent with correlation-id {}", correlationId));
+                LoggingEvent.info(
+                    "A request was sent with correlation-id {}", EXAMPLE_VALID_CORRELATION_ID));
       }
 
       @Test

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/repositories/EmptyApiStorageTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/repositories/EmptyApiStorageTest.java
@@ -7,17 +7,15 @@ import org.junit.jupiter.api.Test;
 
 class EmptyApiStorageTest {
 
+  private final EmptyApiStorage storage = new EmptyApiStorage();
+
   @Test
   void findAllReturnsEmptyList() {
-    var storage = new EmptyApiStorage();
-
     assertThat(storage.findAll()).isEmpty();
   }
 
   @Test
   void findAllReturnsUnmodifiableList() {
-    var storage = new EmptyApiStorage();
-
     var actual = storage.findAll();
 
     assertThatThrownBy(() -> actual.add(null)).isInstanceOf(UnsupportedOperationException.class);


### PR DESCRIPTION
We're using the Spring `@Scheduled` annotation to run a task once an hour.

We've parameterised the rate for the schedule so that we can set it to a
different value for the integration test.  We're setting it to  half a second
instead of an hour for this, so that it only has to wait one second for it to
have executed.