### PR TITLE
Remove `apiVersion` from `Api` object

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/Api.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/domain/model/Api.java
@@ -2,7 +2,6 @@ package uk.gov.api.springboot.domain.model;
 
 /** Domain object for API (metadata) objects. */
 public record Api(
-    String apiVersion,
     String name,
     String description,
     String url,

--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/mappers/V1AlphaMapper.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/mappers/V1AlphaMapper.java
@@ -17,7 +17,7 @@ public class V1AlphaMapper {
    */
   public ApiMetadata convert(Api api) {
     var apiMetadata = new ApiMetadata();
-    apiMetadata.setApiVersion(ApiMetadata.ApiVersion.fromValue(api.apiVersion()));
+    apiMetadata.setApiVersion(ApiMetadata.ApiVersion.API_GOV_UK_V_1_ALPHA);
     var data = new Data();
     data.setName(api.name());
     data.setDescription(api.description());

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/ScheduleHandlerTest.java
@@ -68,7 +68,7 @@ class ScheduleHandlerTest {
   void apisAreSavedToStorage() {
     var entry = new Registry.Entry("123", "https://api-endpoint.example-one");
     when(registry.retrieveAll()).thenReturn(List.of(entry));
-    Api api = new Api("v1", null, null, null, null, null, null);
+    Api api = new Api(null, null, null, null, null, null);
     when(fetcherService.fetch(any())).thenReturn(List.of(api));
 
     handler.fetchAndSaveApis();

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/controllers/v1alpha/ApiControllerIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/controllers/v1alpha/ApiControllerIntegrationTest.java
@@ -122,7 +122,6 @@ class ApiControllerIntegrationTest {
 
   private static Api validApi(String name) {
     return new Api(
-        "api.gov.uk/v1alpha",
         name,
         "the API description",
         "https://api-endpoint.example",

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/controllers/v1alpha/ApiControllerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/controllers/v1alpha/ApiControllerTest.java
@@ -30,8 +30,8 @@ class ApiControllerTest {
 
     @Test
     void returnsListOfApiMetadata(@Mock ApiMetadata metadata1, @Mock ApiMetadata metadata2) {
-      Api api1 = new Api("v1", null, null, null, null, null, null);
-      Api api2 = new Api("v2", null, null, null, null, null, null);
+      Api api1 = new Api("name1", null, null, null, null, null);
+      Api api2 = new Api("name2", null, null, null, null, null);
       when(service.retrieveAll()).thenReturn(List.of(api1, api2));
       when(v1AlphaMapper.convert(api1)).thenReturn(metadata1);
       when(v1AlphaMapper.convert(api2)).thenReturn(metadata2);

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/mappers/V1AlphaMapperTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/mappers/V1AlphaMapperTest.java
@@ -62,7 +62,6 @@ class V1AlphaMapperTest {
 
     private Api getApi() {
       return new Api(
-          "api.gov.uk/v1alpha",
           "name 1",
           "description 1",
           "https://www.example.foo",


### PR DESCRIPTION
Although we'd originally added it, on further inspection it doesn't seem
necessary, as the domain objects are unrelated to API versioning, and is
a constant representation of our underlying API objects, whereas the API
versioning is purely for how we represent it to external users.


