### PR TITLE
Move service configuration code to `config` package

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/ScheduleHandler.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/ScheduleHandler.java
@@ -1,4 +1,4 @@
-package uk.gov.api.springboot.infrastructure;
+package uk.gov.api.springboot.infrastructure.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterIntegrationTest.java
@@ -1,4 +1,4 @@
-package uk.gov.api.springboot.infrastructure;
+package uk.gov.api.springboot.infrastructure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.matchesRegex;

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/SandboxProfileIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/SandboxProfileIntegrationTest.java
@@ -1,4 +1,4 @@
-package uk.gov.api.springboot.infrastructure;
+package uk.gov.api.springboot.infrastructure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/ScheduleHandlerTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/ScheduleHandlerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.api.springboot.infrastructure;
+package uk.gov.api.springboot.infrastructure.config;
 
 import static com.github.valfirst.slf4jtest.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/ScheduledHandlerIntegrationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/ScheduledHandlerIntegrationTest.java
@@ -1,4 +1,4 @@
-package uk.gov.api.springboot.infrastructure;
+package uk.gov.api.springboot.infrastructure.config;
 
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.atLeast;


### PR DESCRIPTION
This moves the `CorrelationIdFilterIntegrationTest` to the `config`
package, to follow the `CorrelationIdFilter`, as well as moving classes
related to the `ScheduleHandler` to the `config` package.
