### PR TITLE
Add HTTP 406 response to contract

### DIFF
--- a/schemas/package-lock.json
+++ b/schemas/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.1.0",
       "license": "OGL-UK-3.0",
       "devDependencies": {
-        "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.1.0",
+        "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.2.0",
         "@stoplight/spectral-cli": "^6.3.0",
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^2.1.1"
       }
     },
     "node_modules/@govuk-data-standards/spectral-ruleset-govuk-public": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.1.0.tgz",
-      "integrity": "sha512-2WiKqxFvNTpgvYqoZs9sXwGWzH0RNhCs0561KmBHqqdIbe/UCKtdicEloBoVV1APs57nI9AHCWqCrXa5qsVFbw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.2.0.tgz",
+      "integrity": "sha512-SVvr12TDTGLgSmJdVLs/WyrxbttSEUK2snuytgltkGZhbvmyv0RPBERz321aG5EDCvXit4UhqzeYKKnCZCng0Q==",
       "dev": true
     },
     "node_modules/@jsep-plugin/regex": {
@@ -2338,9 +2338,9 @@
   },
   "dependencies": {
     "@govuk-data-standards/spectral-ruleset-govuk-public": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.1.0.tgz",
-      "integrity": "sha512-2WiKqxFvNTpgvYqoZs9sXwGWzH0RNhCs0561KmBHqqdIbe/UCKtdicEloBoVV1APs57nI9AHCWqCrXa5qsVFbw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-data-standards/spectral-ruleset-govuk-public/-/spectral-ruleset-govuk-public-0.2.0.tgz",
+      "integrity": "sha512-SVvr12TDTGLgSmJdVLs/WyrxbttSEUK2snuytgltkGZhbvmyv0RPBERz321aG5EDCvXit4UhqzeYKKnCZCng0Q==",
       "dev": true
     },
     "@jsep-plugin/regex": {

--- a/schemas/package.json
+++ b/schemas/package.json
@@ -20,7 +20,7 @@
     "@stoplight/spectral-cli": "^6.3.0",
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
-    "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.1.0"
+    "@govuk-data-standards/spectral-ruleset-govuk-public": "^0.2.0"
   },
   "private": true
 }

--- a/schemas/v1alpha/openapi.yml
+++ b/schemas/v1alpha/openapi.yml
@@ -39,6 +39,9 @@ paths:
                 type: string
                 format: uuidv4
                 pattern: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}"
+        '406':
+          description: The content-negotation, using the `Accept` header, failed
+          content: {}
       parameters:
         - name: correlation-id
           in: header


### PR DESCRIPTION
This also bumps our Spectral rules, which now enforce this.