### PR TITLE
Fix: Always return correlation-id on responses

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilter.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilter.java
@@ -47,9 +47,9 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
     try {
       mdcFacade.put(MdcFacade.CORRELATION_ID, correlationId);
       LOGGER.info("A request was sent with correlation-id {}", correlationId);
+      response.addHeader(CORRELATION_ID_HEADER, correlationId);
       filterChain.doFilter(request, response);
     } finally {
-      response.addHeader(CORRELATION_ID_HEADER, correlationId);
       mdcFacade.clear();
     }
   }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/CorrelationIdFilterTest.java
@@ -41,13 +41,16 @@ class CorrelationIdFilterTest {
   }
 
   @Test
-  void correlationIdIsAddedToResponse() throws ServletException, IOException {
+  void correlationIdIsAddedToResponseBeforeFilter() throws ServletException, IOException {
     String correlationId = UUID.randomUUID().toString();
     when(request.getHeader("correlation-id")).thenReturn(correlationId);
 
     filter.doFilterInternal(request, response, filterChain);
 
-    verify(response).addHeader("correlation-id", correlationId);
+    var inorder = Mockito.inOrder(response, filterChain);
+
+    inorder.verify(response).addHeader("correlation-id", correlationId);
+    inorder.verify(filterChain).doFilter(any(), any());
   }
 
   @Test


### PR DESCRIPTION
It turns out that this ordering is not correct, as the `finally` doesn't
get a chance to amend the response that's generated, so we need to
instead add this before proceeding down the chain.