### PR TITLE
Update the organisation name

### DIFF
--- a/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/SandboxConfiguration.java
+++ b/examples/java/spring-boot/src/main/java/uk/gov/api/springboot/infrastructure/config/SandboxConfiguration.java
@@ -25,7 +25,7 @@ public class SandboxConfiguration {
             "A sample deployment of the Federated API Model's reference implementation",
             "https://federated-api-model-spring-boot-sandbox.london.cloudapps.digital",
             "api-programme@digital.cabinet-office.gov.uk",
-            "CDDO",
+            "Central Digital and Data Office",
             "https://github.com/co-cddo/federated-api-model"));
   }
 }

--- a/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/SandboxConfigurationTest.java
+++ b/examples/java/spring-boot/src/test/java/uk/gov/api/springboot/infrastructure/config/SandboxConfigurationTest.java
@@ -30,7 +30,7 @@ class SandboxConfigurationTest {
                   "A sample deployment of the Federated API Model's reference implementation",
                   "https://federated-api-model-spring-boot-sandbox.london.cloudapps.digital",
                   "api-programme@digital.cabinet-office.gov.uk",
-                  "CDDO",
+                  "Central Digital and Data Office",
                   "https://github.com/co-cddo/federated-api-model"));
     }
   }


### PR DESCRIPTION
When we display this we want the full name to be used rather than the acronym.