### PR TITLE
Add id-token permission

### DIFF
--- a/.github/workflows/main-scorecards-analysis.yml
+++ b/.github/workflows/main-scorecards-analysis.yml
@@ -17,6 +17,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Since v2, the scorecards workflow requires id-token to have write
permission: https://github.com/ossf/scorecard-action