### PR TITLE
Run the openapi-docs workflows when npm packages change

### DIFF
--- a/.github/workflows/openapi-docs-pr.yml
+++ b/.github/workflows/openapi-docs-pr.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/openapi-docs-pr.yml'
       - 'schemas/.spectral.yml'
       - "schemas/*/openapi.yml"
+      - "schemas/package.json"
 
 permissions:
   contents: read

--- a/.github/workflows/openapi-docs-push.yml
+++ b/.github/workflows/openapi-docs-push.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/openapi-docs-push.yml'
       - 'schemas/.spectral.yml'
       - "schemas/*/openapi.yml"
+      - "schemas/package.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
When a new version of spectral cli or the gov.uk spectral ruleset is released, we should lint our openapi document to check it passes any new rules that have been added. Therefore we should run this workflow when the version of either of these packages changes in `package.json`.